### PR TITLE
fix: note pan min/max can be up to 128

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         # https://github.com/codecov/codecov-action/issues/40
-        if: matrix.python-version == 3.10 && matrix.os == "ubuntu-latest"
+        if: matrix.python-version == 3.10 && matrix.os == 'ubuntu-latest'
   publish:
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')

--- a/pyflp/pattern/note.py
+++ b/pyflp/pattern/note.py
@@ -62,8 +62,8 @@ class PatternNote(_FLObject):
     128 for MIDI dragged into the piano roll.
     """
 
-    pan: int = _IntProperty(min_=-128, max_=128)
-    """Min: -64, Max: 64."""
+    pan: int = _IntProperty(min_=-128, max_=127)
+    """Min: -128, Max: 127."""
 
     velocity: int = _UIntProperty(max_=128)
     """Min: 0, Max: 128."""

--- a/pyflp/pattern/note.py
+++ b/pyflp/pattern/note.py
@@ -62,7 +62,7 @@ class PatternNote(_FLObject):
     128 for MIDI dragged into the piano roll.
     """
 
-    pan: int = _IntProperty(min_=-64, max_=64)
+    pan: int = _IntProperty(min_=-128, max_=128)
     """Min: -64, Max: 64."""
 
     velocity: int = _UIntProperty(max_=128)


### PR DESCRIPTION
Note pan can be -128—128. Tested simply by adding one note on the piano roll and using the piano roll pan editor all the way up/down. On FL v 20.9.2 (build 2459), Producer/All Plugins edition, on Apple Silicon mac 12. Test FLP attached.
[test-flp.zip](https://github.com/demberto/PyFLP/files/9124952/test-flp.zip)