### PR TITLE
fix: doc link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PyFLP is a parser for FL Studio project (.flp) files written in Python.
 pip install --upgrade pyflp
 ```
 
-[Alternate ways to install](https://pyflp.rtfd.io/en/latest/installation).
+[Alternate ways to install](https://pyflp.rtfd.io/en/latest/installation.html).
 
 ## ▶ Usage
 


### PR DESCRIPTION
Quick fix-up for the broken docs link in the README.

Apparently, the `.html`-suffix has become required since the migration to Sphinx.