### PR TITLE
fix: remove python version constraint for typing_extensions to prevent import errors for >=3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ license = { text = "GPL-3.0" }
 dependencies = [
   "bytesioex>=0.1.2",
   "colour>=0.1.5",
-  'typing_extensions>=4.3.0;python_version<"3.8"',
+  'typing_extensions>=4.3.0',
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Importing `pyflp` after installation with `pip install -e .` on newer Python version (`>=3.8`) throws a `ModuleNotFoundError`, because `typing_extensions` is imported, but not installed for newer Python versions.

Example:
```
Python 3.10.7 (main, Sep  7 2022, 22:40:42) [GCC 11.2.1 20220219] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyflp
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/python_project/pyflp/__init__.py", line 53, in <module>
    from .project import VALID_PPQS, FileFormat, Project, ProjectID
  File "/python_project/pyflp/project.py", line 31, in <module>
    from typing_extensions import Unpack
ModuleNotFoundError: No module named 'typing_extensions'
```

After applying this fix importing `pyflp` works without throwing an error.
(Parsing example is just to show that pyflp was imported correctly, the error thrown is unrelated to the `typing_extension` problem)
```
Python 3.10.7 (main, Sep  7 2022, 22:40:42) [GCC 11.2.1 20220219] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyflp
>>> project = pyflp.parse("../test_data/melody.flp")
/python_project/pyflp/pyflp/__init__.py:151: RuntimeWarning: Event 212 not parsed entirely; parsed 18, found 52 bytes
  events.append(event_type(id, value))
/python_project/pyflp/pyflp/__init__.py:151: RuntimeWarning: Event 215 not parsed entirely; parsed 158, found 168 bytes
  events.append(event_type(id, value))
```