### PR TITLE
fix: ci fails with python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - '*'
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
         os: ["macos-latest", "windows-latest", "ubuntu-latest"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This fixes the following error for the currently broken master branch CI:

```
Run actions/setup-python@v4
Version 3.[1](https://github.com/demberto/PyFLP/actions/runs/3123167570/jobs/5065616192#step:3:1)1 was not found in the local cache
Error: Version 3.11 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```