### PR TITLE
fix(typo): in handbook.rst from 'instument' to 'instrument'

### DIFF
--- a/docs/handbook.rst
+++ b/docs/handbook.rst
@@ -105,7 +105,7 @@ It is possible to undo both of these:
    project.licensed = True
 
    # Unlock trial version native plugins
-   for instument in project.channels.instruments:
+   for instrument in project.channels.instruments:
        instrument.plugin.demo_mode = False
 
    for insert in project.mixer:


### PR DESCRIPTION
There was a typo in the licensing code in docs/handbook.rst declaring `instument` and using `instruments` resulting in a Python error. 

> Note : The [readthedocs](https://pyflp.readthedocs.io/en/latest/handbook.html#unlocking-demo-version-flps) code is not indented properly even though the .rst source file is. So you have to edit manually after copy pasting (yes i am lazy). 
_See below :_ 
<img width="374" height="83" alt="image" src="https://github.com/user-attachments/assets/089117fb-cfd2-456c-9d94-991416beaa5e" />
