### PR TITLE
fix: restore EventEnum(value) lookup on Python 3.12+

### DIFF
--- a/pyflp/_events.py
+++ b/pyflp/_events.py
@@ -59,6 +59,34 @@ class _EventEnumMeta(enum.EnumMeta):
         """
         return obj in tuple(self)
 
+    def __call__(cls, value: object, *args: object, **kwds: object) -> object:
+        """Look up ``value`` even when ``cls`` (typically the base
+        ``EventEnum`` itself) defines no members of its own.
+
+        ``EventEnum`` is intentionally empty -- real event IDs only exist on
+        its subclasses (``ChannelID``, ``PluginID``, etc) -- and callers are
+        expected to be able to do ``EventEnum(raw_id)`` and have
+        :meth:`EventEnum._missing_` dispatch to whichever subclass defines
+        that value. Since Python 3.12, ``enum.EnumMeta.__call__`` raises
+        ``TypeError`` before ever reaching ``_missing_`` when called on an
+        aggregate enum class with zero direct members, which breaks this
+        pattern. Detect exactly that case and route to ``_missing_``
+        ourselves; everything else (name-based construction, lookups on
+        non-empty subclasses, etc.) is left to the normal enum machinery.
+        """
+        if (
+            not args
+            and not kwds
+            and not len(cls)
+            and isinstance(value, int)
+            and hasattr(cls, "_missing_")
+        ):
+            member = cls._missing_(value)
+            if member is not None:
+                return member
+            raise ValueError(f"{value!r} is not a valid {cls.__qualname__}")
+        return super().__call__(value, *args, **kwds)
+
 
 class EventEnum(int, enum.Enum, metaclass=_EventEnumMeta):
     """IDs used by events.


### PR DESCRIPTION
Same fix idea as #204.

Python 3.12 changed `enum.EnumMeta.__call__` to raise `TypeError` when called on an aggregate Enum subclass with zero members of its own, before `_missing_` is ever invoked. `EventEnum` is intentionally such a class, real event IDs only live on its subclasses (`ChannelID`, `PluginID`, etc). So `pyflp.parse()` has been broken on Python 3.12+ since that release.

This overrides `_EventEnumMeta.__call__` to detect exactly that case (no positional/keyword args, integer value, zero members on `cls`) and route straight to `_missing_`, restoring pre-3.12 lookup behaviour. Every other call path (name-based construction, lookups on non-empty subclasses, etc.) falls through unchanged to the normal enum machinery.

Fixes #183, #201.

Verified against:
- The two sample files attached to #201 (`empty.flp`, `untitled.flp`, FL Studio 25.1.3.4922), both now parse cleanly (with the pre-existing, unrelated `VSTPluginEvent: Unknown marker 12` warning on one of them).
- A small local corpus of FL Studio 11.1.1 / 12.5.1.5 / 24.2.1.4526 projects.

*Disclaimer: AI assisted in writing this fix.*